### PR TITLE
Add support for Base Folder

### DIFF
--- a/src/fs/CloudinaryFs.php
+++ b/src/fs/CloudinaryFs.php
@@ -182,7 +182,7 @@ class CloudinaryFs extends Fs
     {
         try {
             $client = $this->client();
-            $publicId = $this->pathToPublicId($path);
+            $publicId = $this->appendBaseFolderToPath($this->pathToPublicId($path));
             $client->uploadApi()->destroy($publicId, [
                 'invalidate' => true,
             ]);
@@ -195,8 +195,8 @@ class CloudinaryFs extends Fs
     {
         try {
             $client = $this->client();
-            $publicId = $this->pathToPublicId($path);
-            $newPublicId = $this->pathToPublicId($newPath);
+            $publicId = $this->appendBaseFolderToPath($this->pathToPublicId($path));
+            $newPublicId = $this->appendBaseFolderToPath($this->pathToPublicId($newPath));
             $client->uploadApi()->rename($publicId, $newPublicId, [
                 'invalidate' => true,
             ]);
@@ -233,6 +233,7 @@ class CloudinaryFs extends Fs
     {
         try {
             $client = $this->client();
+            $uriPath = $this->appendBaseFolderToPath($uriPath);
             $url = $this->pathToUrl($uriPath);
             $file = @fopen($url, 'rb');
             if (!$file) {
@@ -285,7 +286,25 @@ class CloudinaryFs extends Fs
             ],
         ];
 
+        $url = Craft::parseEnv($this->url);
+        if ($url) {
+            $hostname = parse_url($url, PHP_URL_HOST);
+
+            if ($hostname !== 'res.cloudinary.com') {
+                $config['private_cdn'] = TRUE;
+                $config['secure_distribution'] = $hostname;
+            }
+        }
+
         return new Cloudinary($config);
+    }
+
+    protected function appendBaseFolderToPath(string $path): string
+    {
+        if (!empty($this->baseFolder)) {
+            $path = Craft::parseEnv($this->baseFolder) . '/' . $path;
+        }
+        return $path;
     }
 
     protected function pathToPublicId(string $path): string

--- a/src/fs/CloudinaryFs.php
+++ b/src/fs/CloudinaryFs.php
@@ -18,6 +18,8 @@ class CloudinaryFs extends Fs
 
     public string $apiSecret = '';
 
+    public string $baseFolder = '';
+
     public bool $dynamicFolders = false;
 
     public static function displayName(): string
@@ -128,6 +130,10 @@ class CloudinaryFs extends Fs
                 $uploadOptions['asset_folder'] = $this->pathToFolder($path);
             }
 
+            if(!empty($this->baseFolder)) {
+                $uploadOptions['folder'] = Craft::parseEnv($this->baseFolder);
+            }
+
             $client->uploadApi()->upload($contents, $uploadOptions);
         } catch (Exception $e) {
             throw new FsException($e->getMessage(), $e->getCode(), $e);
@@ -145,6 +151,10 @@ class CloudinaryFs extends Fs
 
             if ($this->dynamicFolders) {
                 $uploadOptions['asset_folder'] = $this->pathToFolder($path);
+            }
+
+            if(!empty($this->baseFolder)) {
+                $uploadOptions['folder'] = Craft::parseEnv($this->baseFolder);
             }
 
             $client->uploadApi()->upload($stream, $uploadOptions);
@@ -207,6 +217,10 @@ class CloudinaryFs extends Fs
 
             if ($this->dynamicFolders) {
                 $uploadOptions['asset_folder'] = $this->pathToFolder($path);
+            }
+
+            if(!empty($this->baseFolder)) {
+                $uploadOptions['folder'] = Craft::parseEnv($this->baseFolder);
             }
 
             $client->uploadApi()->upload($url, $uploadOptions);

--- a/src/imagetransforms/CloudinaryTransformer.php
+++ b/src/imagetransforms/CloudinaryTransformer.php
@@ -20,10 +20,15 @@ class CloudinaryTransformer extends Component implements ImageTransformerInterfa
         
         $isCloudinaryFs = $fs instanceof CloudinaryFs;
         $hasDynamicFolders = $isCloudinaryFs && $fs->dynamicFolders;
+        $hasBaseFolder = !(empty($fs->baseFolder));
 
         $publicId = $asset->getUrl();
         if ($isCloudinaryFs) {
             $publicId = $hasDynamicFolders ? basename($asset->getPath()) : $asset->getPath();
+        }
+        if($hasBaseFolder) {
+            $baseFolder = Craft::parseEnv($fs->baseFolder) ?? $fs->baseFolder;
+            $publicId = '/'. $baseFolder . '/' . $publicId;
         }
         
         /** @var CloudinaryFs $transformFs */

--- a/src/templates/fsSettings.html
+++ b/src/templates/fsSettings.html
@@ -1,6 +1,16 @@
 {% import "_includes/forms" as forms %}
 
 {{ forms.autosuggestField({
+label: "Base Folder"|t('cloudinary'),
+id: 'baseFolder',
+name: 'baseFolder',
+suggestEnvVars: true,
+value: fs.baseFolder,
+errors: fs.getErrors('baseFolder'),
+required: false,
+}) }}
+
+{{ forms.autosuggestField({
     label: "Cloud Name"|t('cloudinary'),
     id: 'cloudName',
     name: 'cloudName',


### PR DESCRIPTION
- Add the Base Folder property to the `Cloudinary FS` class
- Use the `base folder` value to set Cloudinary upload options and generate correct transform URL