### PR TITLE
Add webhook notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,7 @@ In addition, you can incorporate any of [Cloudinary's transformation options](ht
 <img src="{{ asset.getUrl(thumb) }}">
 ```
 Transformation options should be in camelCase, meaning `aspect_ratio` becomes `aspectRatio`, or `fetch_format` becomes `fetchFornat`.
+
+## Webhook notifications
+
+To keep Craft aligned with changes made directly in Cloudinary, activate webhook notifications. Simply go to your [Cloudinary settings](https://console.cloudinary.com/settings/c-4547d495209fcc884b171f78858f04/webhooks) and add a new notification URL. Point it to the base URL of your website followed by `/actions/cloudinary/notifications/process?volume={VOLUME_ID}`. Remember to replace `{VOLUME_ID}` with the relevant asset volume ID. Enable the relevant notification types: `upload`, `delete`, `rename`, `create_folder`, and `delete_folder`. Keep in mind, this setup only functions in local development if your local domain is publicly accessible via a service like ngrok. Additionally, note that the webhook may struggle with a large volume of operations. If you frequently make extensive changes in the Cloudinary Console, consider re-indexing your asset volume instead.

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -8,9 +8,11 @@ use craft\elements\Asset;
 use craft\events\DefineBehaviorsEvent;
 use craft\events\GenerateTransformEvent;
 use craft\events\RegisterComponentTypesEvent;
+use craft\events\RegisterUrlRulesEvent;
 use craft\models\ImageTransform;
 use craft\services\Fs;
 use craft\services\ImageTransforms;
+use craft\web\UrlManager;
 use thomasvantuycom\craftcloudinary\behaviors\CloudinaryBehavior;
 use thomasvantuycom\craftcloudinary\fs\CloudinaryFs;
 use thomasvantuycom\craftcloudinary\imagetransforms\CloudinaryTransformer;
@@ -47,6 +49,10 @@ class Plugin extends BasePlugin
 
         Event::on(ImageTransform::class, ImageTransform::EVENT_DEFINE_BEHAVIORS, function(DefineBehaviorsEvent $event) {
             $event->behaviors['cloudinary'] = CloudinaryBehavior::class;
+        });
+
+        Event::on(UrlManager::class, UrlManager::EVENT_REGISTER_SITE_URL_RULES, function(RegisterUrlRulesEvent $event) {
+            $event->rules['cloudinary/notifications'] = 'cloudinary/notifications/receive';
         });
     }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -8,11 +8,9 @@ use craft\elements\Asset;
 use craft\events\DefineBehaviorsEvent;
 use craft\events\GenerateTransformEvent;
 use craft\events\RegisterComponentTypesEvent;
-use craft\events\RegisterUrlRulesEvent;
 use craft\models\ImageTransform;
 use craft\services\Fs;
 use craft\services\ImageTransforms;
-use craft\web\UrlManager;
 use thomasvantuycom\craftcloudinary\behaviors\CloudinaryBehavior;
 use thomasvantuycom\craftcloudinary\fs\CloudinaryFs;
 use thomasvantuycom\craftcloudinary\imagetransforms\CloudinaryTransformer;
@@ -49,10 +47,6 @@ class Plugin extends BasePlugin
 
         Event::on(ImageTransform::class, ImageTransform::EVENT_DEFINE_BEHAVIORS, function(DefineBehaviorsEvent $event) {
             $event->behaviors['cloudinary'] = CloudinaryBehavior::class;
-        });
-
-        Event::on(UrlManager::class, UrlManager::EVENT_REGISTER_SITE_URL_RULES, function(RegisterUrlRulesEvent $event) {
-            $event->rules['cloudinary/notifications'] = 'cloudinary/notifications/receive';
         });
     }
 }

--- a/src/controllers/NotificationsController.php
+++ b/src/controllers/NotificationsController.php
@@ -6,6 +6,8 @@ use Cloudinary\Configuration\Configuration;
 use Cloudinary\Utils\SignatureVerifier;
 use Craft;
 use craft\elements\Asset;
+use craft\db\Query;
+use craft\db\Table;
 use craft\helpers\App;
 use craft\helpers\Assets;
 use craft\records\Asset as AssetRecord;
@@ -30,6 +32,7 @@ class NotificationsController extends Controller
             // Verify that volume is valid
             $volumeHandle = $this->request->getRequiredQueryParam('volume');
             $volume = Craft::$app->getVolumes()->getVolumeByHandle($volumeHandle);
+            $volumeId = $volume->id;
             $fs = $volume->getFs();
 
             if (!($fs instanceof CloudinaryFs)) {
@@ -47,200 +50,220 @@ class NotificationsController extends Controller
                 return $this->asFailure();
             }
 
-            // Verify that notification is triggered by Console UI action
-            $triggeredBy = $this->request->getRequiredBodyParam('notification_context.triggered_by.source');
-            if ($triggeredBy !== 'ui') {
-                return $this->asFailure();
-            }
-
             // Handle notification
-            $type = $this->request->getRequiredBodyParam('notification_type');
-            
-            if ($type === 'create_folder') {
-                $volumeId = $volume->id;
-                $name = $this->request->getRequiredBodyParam('folder_name');
-                $path = $this->request->getRequiredBodyParam('folder_path');
+            $notificationType = $this->request->getRequiredBodyParam('notification_type');
 
-                // Check if folder exists
-                $folderRecord = VolumeFolderRecord::findOne([
-                    'volumeId' => $volumeId,
-                    'path' => $path . '/',
-                ]);
-
-                if ($folderRecord !== null) {
-                    return $this->asSuccess();
-                }
-
-                // Get parent folder ID
-                $parentFolderRecord = VolumeFolderRecord::findOne([
-                    'volumeId' => $volumeId,
-                    'path' => ($name === $path) ? '' : dirname($path) . '/',
-                ]);
-
-                $parentId = $parentFolderRecord->id;
-
-                // Store folder
-                $newFolderRecord = new VolumeFolderRecord([
-                    'parentId' => $parentId,
-                    'volumeId' => $volumeId,
-                    'name' => $name,
-                    'path' => $path . '/',
-                ]);
-                $newFolderRecord->save();
-
-                return $this->asSuccess();
-            }
-
-            if ($type === 'delete_folder') {
-                $path = $this->request->getRequiredBodyParam('folder_path');
-
-                // Delete folder
-                VolumeFolderRecord::deleteAll([
-                    'volumeId' => $volume->id,
-                    'path' => $path . '/',
-                ]);
-
-                return $this->asSuccess();
-            }
-
-            if ($type === 'upload') {
-                $volumeId = $volume->id;
-                $publicId = $this->request->getRequiredBodyParam('public_id');
-                $format = $this->request->getRequiredBodyParam('format');
-                $folder = $this->request->getRequiredBodyParam('folder');
-                $size = $this->request->getRequiredBodyParam('bytes');
-
-                // Get folder ID
-                $folderRecord = VolumeFolderRecord::findOne([
-                    'volumeId' => $volumeId,
-                    'path' => $folder === '' ? '' : $folder . '/',
-                ]);
-
-                // Check if asset exists
-                $folderId = $folderRecord->id;
-                $filename = basename($publicId) . '.' . $format;
-
-                $assetRecord = AssetRecord::findOne([
-                    'volumeId' => $volumeId,
-                    'folderId' => $folderId,
-                    'filename' => $filename,
-                ]);
-
-                if ($assetRecord !== null) {
-                    return $this->asSuccess();
-                }
-
-                // Store Asset
-                $kind = Assets::getFileKindByExtension($filename);
-
-                $asset = new Asset([
-                    'volumeId' => $volumeId,
-                    'folderId' => $folderId,
-                    'filename' => $filename,
-                    'kind' => $kind,
-                    'size' => $size,
-                ]);
-
-                if ($kind === Asset::KIND_IMAGE) {
-                    $asset->width = $this->request->getRequiredBodyParam('width');
-                    $asset->height = $this->request->getRequiredBodyParam('height');
-                }
-                
-                $asset->setScenario(Asset::SCENARIO_INDEX);
-                Craft::$app->getElements()->saveElement($asset);
-
-                return $this->asSuccess();
-            }
-
-            if ($type === 'delete') {
-                $volumeId = $volume->id;
-                $resources = $this->request->getRequiredBodyParam('resources');
-
-                foreach ($resources as $resource) {
-                    $resourceType = $resource['resource_type'];
-                    $publicId = $resource['public_id'];
-                    $folder = $resource['folder'];
-
-                    $filename = basename($publicId);
-                    $folderPath = $folder === '' ? '' : $folder . '/';
-
-                    $assetQuery = Asset::find()
-                        ->volumeId($volumeId)
-                        ->folderPath($folderPath);
-                    
-                    if ($resourceType === 'raw') {
-                        $assetQuery->filename($filename);
-                    } else {
-                        $assetQuery->filename("$filename.*");
-                        if ($resourceType === 'image') {
-                            $assetQuery->kind('image');
-                        } else {
-                            $assetQuery->kind(['video', 'audio']);
-                        }
-                    }
-
-                    $asset = $assetQuery->one();
-                        
-                    if($asset !== null) {
-                        Craft::$app->getElements()->deleteElement($asset);
-                    }
-                }
-            }
-
-            if ($type === 'rename') {
-                $volumeId = $volume->id;
-                $resourceType = $this->request->getRequiredBodyParam('resource_type');
-                $fromPublicId = $this->request->getRequiredBodyParam('from_public_id');
-                $toPublicId = $this->request->getRequiredBodyParam('to_public_id');
-                $folder = $this->request->getRequiredBodyParam('folder');
-                
-                $fromFilename = basename($fromPublicId);
-                $fromFolder = dirname($fromPublicId);
-                $fromFolderPath = $fromFolder === '.' ? '' : $fromFolder . '/';
-                $toFilename = basename($toPublicId);
-                $toFolderPath = $folder === '' ? '' : $folder . '/';
-
-                $assetQuery = Asset::find()
-                    ->volumeId($volumeId)
-                    ->folderPath($fromFolderPath);
-                
-                if ($resourceType === 'raw') {
-                    $assetQuery->filename($fromFilename);
-                } else {
-                    $assetQuery->filename("$fromFilename.*");
-                    if ($resourceType === 'image') {
-                        $assetQuery->kind('image');
-                    } else {
-                        $assetQuery->kind(['video', 'audio']);
-                    }
-                }
-
-                $asset = $assetQuery->one();
-
-                if ($asset !== null) {
-                    if ($fromFolderPath !== $toFolderPath) {
-                        $folderRecord = VolumeFolderRecord::findOne([
-                            'volumeId' => $volumeId,
-                            'path' => $toFolderPath,
-                        ]);
-
-                        $asset->folderId = $folderRecord->id;
-                    }
-
-                    if ($fromFilename !== $toFilename) {
-                        if ($resourceType === 'raw') {
-                            $asset->filename = $toFilename;
-                        } else {
-                            $extension = pathinfo($asset->filename, PATHINFO_EXTENSION);
-                            $asset->filename = "$toFilename.$extension";
-                        }
-                    }
-
-                    Craft::$app->getElements()->saveElement($asset);
-                }
+            switch($notificationType) {
+                case 'create_folder':
+                    return $this->_handleCreateFolder($volumeId);
+                case 'delete_folder':
+                    return $this->_handleDeleteFolder($volumeId);
+                case 'upload':
+                    return $this->_handleUpload($volumeId);
+                case 'delete':
+                    return $this->_handleDelete($volumeId);
+                case 'rename':
+                    return $this->_handleRename($volumeId);
+                default:
+                    return $this->asSucces();
             }
         } catch (Throwable $error) {
-            return $this->asFailure();
+            return $this->asFailure($error->getMessage());
+        }
+
+        return $this->asSuccess();
+    }
+
+    private function _handleCreateFolder($volumeId) {
+        $name = $this->request->getRequiredBodyParam('folder_name');
+        $path = $this->request->getRequiredBodyParam('folder_path');
+
+        // Check if folder exists
+        $existingFolderQuery = (new Query())
+            ->from([Table::VOLUMEFOLDERS])
+            ->where([
+                'volumeId' => $volumeId,
+                'path' => $path . '/'
+            ]);
+        
+        if ($existingFolderQuery->exists()) {
+            return $this->asSuccess();
+        }
+       
+        // Get parent folder ID
+        $parentId = (new Query())
+            ->select('id')
+            ->from(Table::VOLUMEFOLDERS)
+            ->where([
+                'volumeId' => $volumeId,
+                'path' => ($name === $path) ? '' : dirname($path) . '/',
+            ])
+            ->scalar();
+
+        // Store folder
+        $record = new VolumeFolderRecord([
+            'parentId' => $parentId,
+            'volumeId' => $volumeId,
+            'name' => $name,
+            'path' => $path . '/',
+        ]);
+        $record->save();
+
+        return $this->asSuccess();
+    }
+
+    private function _handleDeleteFolder($volumeId) {
+        $path = $this->request->getRequiredBodyParam('folder_path');
+
+        // Delete folder
+        VolumeFolderRecord::deleteAll([
+            'volumeId' => $volumeId,
+            'path' => $path . '/',
+        ]);
+
+        return $this->asSuccess();
+    }
+
+    private function _handleUpload($volumeId) {
+        $publicId = $this->request->getRequiredBodyParam('public_id');
+        $format = $this->request->getRequiredBodyParam('format');
+        $folder = $this->request->getRequiredBodyParam('folder');
+        $size = $this->request->getRequiredBodyParam('bytes');
+
+        // Get folder ID
+        $folderId = (new Query())
+            ->select('id')
+            ->from(Table::VOLUMEFOLDERS)
+            ->where([
+                'volumeId' => $volumeId,
+                'path' => $folder === '' ? '' : $folder . '/',
+            ])
+            ->scalar();
+
+        // Check if asset exists
+        $filename = basename($publicId) . '.' . $format;
+
+        $existingAssetQuery = (new Query())
+            ->from(['assets' => Table::ASSETS])
+            ->innerJoin(['elements' => Table::ELEMENTS], '[[elements.id]] = [[assets.id]]')
+            ->where([
+                'assets.volumeId' => $volumeId,
+                'assets.folderId' => $folderId,
+                'assets.filename' => $filename,
+                'elements.dateDeleted' => null,
+            ]);
+
+        if ($existingAssetQuery->exists()) {
+            return $this->asSuccess();
+        }
+
+        // Store Asset
+        $kind = Assets::getFileKindByExtension($filename);
+
+        $asset = new Asset([
+            'volumeId' => $volumeId,
+            'folderId' => $folderId,
+            'filename' => $filename,
+            'kind' => $kind,
+            'size' => $size,
+        ]);
+
+        if ($kind === Asset::KIND_IMAGE) {
+            $asset->width = $this->request->getRequiredBodyParam('width');
+            $asset->height = $this->request->getRequiredBodyParam('height');
+        }
+        
+        $asset->setScenario(Asset::SCENARIO_INDEX);
+        Craft::$app->getElements()->saveElement($asset);
+
+        return $this->asSuccess();
+    }
+
+    private function _handleDelete($volumeId) {
+        $resources = $this->request->getRequiredBodyParam('resources');
+
+        foreach ($resources as $resource) {
+            $resourceType = $resource['resource_type'];
+            $publicId = $resource['public_id'];
+            $folder = $resource['folder'];
+
+            $filename = basename($publicId);
+            $folderPath = $folder === '' ? '' : $folder . '/';
+
+            $assetQuery = Asset::find()
+                ->volumeId($volumeId)
+                ->folderPath($folderPath);
+            
+            if ($resourceType === 'raw') {
+                $assetQuery->filename($filename);
+            } else {
+                $assetQuery->filename("$filename.*");
+                if ($resourceType === 'image') {
+                    $assetQuery->kind('image');
+                } else {
+                    $assetQuery->kind(['video', 'audio']);
+                }
+            }
+
+            $asset = $assetQuery->one();
+                
+            if($asset !== null) {
+                Craft::$app->getElements()->deleteElement($asset);
+            }
+        }
+
+        return $this->asSuccess();
+    }
+
+    private function _handleRename($volumeId) {
+        $resourceType = $this->request->getRequiredBodyParam('resource_type');
+        $fromPublicId = $this->request->getRequiredBodyParam('from_public_id');
+        $toPublicId = $this->request->getRequiredBodyParam('to_public_id');
+        $folder = $this->request->getRequiredBodyParam('folder');
+        
+        $fromFilename = basename($fromPublicId);
+        $fromFolder = dirname($fromPublicId);
+        $fromFolderPath = $fromFolder === '.' ? '' : $fromFolder . '/';
+        $toFilename = basename($toPublicId);
+        $toFolderPath = $folder === '' ? '' : $folder . '/';
+
+        $assetQuery = Asset::find()
+            ->volumeId($volumeId)
+            ->folderPath($fromFolderPath);
+        
+        if ($resourceType === 'raw') {
+            $assetQuery->filename($fromFilename);
+        } else {
+            $assetQuery->filename("$fromFilename.*");
+            if ($resourceType === 'image') {
+                $assetQuery->kind('image');
+            } else {
+                $assetQuery->kind(['video', 'audio']);
+            }
+        }
+
+        $asset = $assetQuery->one();
+
+        if ($asset !== null) {
+            if ($fromFolderPath !== $toFolderPath) {
+                $folderRecord = VolumeFolderRecord::findOne([
+                    'volumeId' => $volumeId,
+                    'path' => $toFolderPath,
+                ]);
+
+                $asset->folderId = $folderRecord->id;
+            }
+
+            if ($fromFilename !== $toFilename) {
+                if ($resourceType === 'raw') {
+                    $asset->filename = $toFilename;
+                } else {
+                    $extension = pathinfo($asset->filename, PATHINFO_EXTENSION);
+                    $asset->filename = "$toFilename.$extension";
+                }
+            }
+
+            Craft::$app->getElements()->saveElement($asset);
         }
 
         return $this->asSuccess();

--- a/src/controllers/NotificationsController.php
+++ b/src/controllers/NotificationsController.php
@@ -5,12 +5,11 @@ namespace thomasvantuycom\craftcloudinary\controllers;
 use Cloudinary\Configuration\Configuration;
 use Cloudinary\Utils\SignatureVerifier;
 use Craft;
-use craft\elements\Asset;
 use craft\db\Query;
 use craft\db\Table;
+use craft\elements\Asset;
 use craft\helpers\App;
 use craft\helpers\Assets;
-use craft\records\Asset as AssetRecord;
 use craft\records\VolumeFolder as VolumeFolderRecord;
 use craft\web\Controller;
 use thomasvantuycom\craftcloudinary\fs\CloudinaryFs;
@@ -53,7 +52,7 @@ class NotificationsController extends Controller
             // Handle notification
             $notificationType = $this->request->getRequiredBodyParam('notification_type');
 
-            switch($notificationType) {
+            switch ($notificationType) {
                 case 'create_folder':
                     return $this->_handleCreateFolder($volumeId);
                 case 'delete_folder':
@@ -72,7 +71,8 @@ class NotificationsController extends Controller
         }
     }
 
-    private function _handleCreateFolder($volumeId) {
+    private function _handleCreateFolder($volumeId)
+    {
         $name = $this->request->getRequiredBodyParam('folder_name');
         $path = $this->request->getRequiredBodyParam('folder_path');
 
@@ -81,7 +81,7 @@ class NotificationsController extends Controller
             ->from([Table::VOLUMEFOLDERS])
             ->where([
                 'volumeId' => $volumeId,
-                'path' => $path . '/'
+                'path' => $path . '/',
             ]);
         
         if ($existingFolderQuery->exists()) {
@@ -110,7 +110,8 @@ class NotificationsController extends Controller
         return $this->asSuccess();
     }
 
-    private function _handleDeleteFolder($volumeId) {
+    private function _handleDeleteFolder($volumeId)
+    {
         $path = $this->request->getRequiredBodyParam('folder_path');
 
         // Delete folder
@@ -122,7 +123,8 @@ class NotificationsController extends Controller
         return $this->asSuccess();
     }
 
-    private function _handleUpload($volumeId) {
+    private function _handleUpload($volumeId)
+    {
         $publicId = $this->request->getRequiredBodyParam('public_id');
         $format = $this->request->getRequiredBodyParam('format');
         $folder = $this->request->getRequiredBodyParam('folder');
@@ -177,7 +179,8 @@ class NotificationsController extends Controller
         return $this->asSuccess();
     }
 
-    private function _handleDelete($volumeId) {
+    private function _handleDelete($volumeId)
+    {
         $resources = $this->request->getRequiredBodyParam('resources');
 
         foreach ($resources as $resource) {
@@ -205,7 +208,7 @@ class NotificationsController extends Controller
 
             $asset = $assetQuery->one();
                 
-            if($asset !== null) {
+            if ($asset !== null) {
                 Craft::$app->getElements()->deleteElement($asset);
             }
         }
@@ -213,7 +216,8 @@ class NotificationsController extends Controller
         return $this->asSuccess();
     }
 
-    private function _handleRename($volumeId) {
+    private function _handleRename($volumeId)
+    {
         $resourceType = $this->request->getRequiredBodyParam('resource_type');
         $fromPublicId = $this->request->getRequiredBodyParam('from_public_id');
         $toPublicId = $this->request->getRequiredBodyParam('to_public_id');

--- a/src/controllers/NotificationsController.php
+++ b/src/controllers/NotificationsController.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace thomasvantuycom\craftcloudinary\controllers;
+
+use Cloudinary\Configuration\Configuration;
+use Cloudinary\Utils\SignatureVerifier;
+use Craft;
+use craft\helpers\App;
+use craft\records\VolumeFolder as VolumeFolderRecord;
+use craft\web\Controller;
+use thomasvantuycom\craftcloudinary\fs\CloudinaryFs;
+use Throwable;
+use yii\web\Response;
+
+class NotificationsController extends Controller
+{
+    public $enableCsrfValidation = false;
+
+    protected array|bool|int $allowAnonymous = true;
+
+    public function actionReceive(): Response
+    {
+        $this->requirePostRequest();
+        $this->requireAcceptsJson();
+
+        try {
+            // Verify that volume is valid
+            $volumeHandle = $this->request->getRequiredQueryParam('volume');
+            $volume = Craft::$app->getVolumes()->getVolumeByHandle($volumeHandle);
+            $fs = $volume->getFs();
+
+            if (!($fs instanceof CloudinaryFs)) {
+                return $this->asFailure();
+            }
+
+            // Verify notification signature
+            Configuration::instance()->cloud->apiSecret = App::parseEnv($fs->apiSecret);
+            Configuration::instance()->cloud->apiSecret = App::parseEnv("abcd");
+            
+            $body = $this->request->getRawBody();
+            $timestamp = $this->request->getHeaders()->get('X-Cld-Timestamp');
+            $signature = $this->request->getHeaders()->get('X-Cld-Signature');
+
+            if (SignatureVerifier::verifyNotificationSignature($body, $timestamp, $signature) === false) {
+                return $this->asFailure();
+            }
+
+            // Verify that notification is triggered by Console UI action
+            $triggeredBy = $this->request->getRequiredBodyParam('notification_context.triggered_by.source');
+            if ($triggeredBy !== 'ui') {
+                return $this->asFailure();
+            }
+
+            // Handle notification
+            $type = $this->request->getRequiredBodyParam('notification_type');
+            
+            if ($type === 'create_folder') {
+                $folderName = $this->request->getRequiredBodyParam('folder_name');
+                $folderPath = $this->request->getRequiredBodyParam('folder_path');
+
+                // Check if folder exists
+                $existingFolder = Craft::$app->getAssets()->findFolder([
+                    'volumeId' => $volume->id,
+                    'path' => $folderPath . '/',
+                ]);
+
+                if ($existingFolder !== null) {
+                    return $this->asSuccess();
+                }
+
+                // Get parent folder
+                $criteria = ['volumeId' => $volume->id];
+
+                if ($folderName === $folderPath) {
+                    $criteria['parentId'] = ':empty:';
+                } else {
+                    $criteria['path'] = dirname($folderPath) . '/';
+                }
+
+                $parentFolder = Craft::$app->getAssets()->findFolder($criteria);
+
+                // Store folder
+                $record = new VolumeFolderRecord();
+                $record->parentId = $parentFolder->id;
+                $record->volumeId = $volume->id;
+                $record->name = $folderName;
+                $record->path = $folderPath . '/';
+                $record->save();
+
+                return $this->asSuccess();
+            }
+
+            if ($type === 'delete_folder') {
+                $folderPath = $this->request->getRequiredBodyParam('folder_path');
+
+                // Check if folder exists
+                $existingFolder = Craft::$app->getAssets()->findFolder([
+                    'volumeId' => $volume->id,
+                    'path' => $folderPath . '/',
+                ]);
+
+                if ($existingFolder === null) {
+                    return $this->asSuccess();
+                }
+
+                // Delete folder
+                VolumeFolderRecord::deleteAll([
+                    'volumeId' => $volume->id,
+                    'path' => $folderPath . '/',
+                ]);
+
+                return $this->asSuccess();
+            }
+        } catch (Throwable $error) {
+            return $this->asFailure();
+        }
+
+        return $this->asSuccess();
+    }
+}

--- a/src/controllers/NotificationsController.php
+++ b/src/controllers/NotificationsController.php
@@ -65,13 +65,11 @@ class NotificationsController extends Controller
                 case 'rename':
                     return $this->_handleRename($volumeId);
                 default:
-                    return $this->asSucces();
+                    return $this->asSuccess();
             }
         } catch (Throwable $error) {
             return $this->asFailure($error->getMessage());
         }
-
-        return $this->asSuccess();
     }
 
     private function _handleCreateFolder($volumeId) {

--- a/src/controllers/NotificationsController.php
+++ b/src/controllers/NotificationsController.php
@@ -132,7 +132,6 @@ class NotificationsController extends Controller
     private function _processUpload($volumeId): Response
     {
         $publicId = $this->request->getRequiredBodyParam('public_id');
-        $format = $this->request->getRequiredBodyParam('format');
         $folder = $this->request->getRequiredBodyParam('folder');
         $size = $this->request->getRequiredBodyParam('bytes');
 
@@ -147,7 +146,15 @@ class NotificationsController extends Controller
             ->scalar();
 
         // Check if asset exists
-        $filename = basename($publicId) . '.' . $format;
+        $filename = basename($publicId);
+
+        $resourceType = $this->request->getRequiredBodyParam('resource_type');
+        
+        if($resourceType !== 'raw') {
+            $format = $this->request->getRequiredBodyParam('format');
+
+            $filename = $filename . '.' . $format;
+        }
 
         $existingAssetQuery = (new Query())
             ->from(['assets' => Table::ASSETS])


### PR DESCRIPTION
This pull request introduces support for webhook notifications, enhancing the integration between Craft and Cloudinary. With this implementation, user actions within the Cloudinary UI trigger real-time updates in the Craft filesystem. By leveraging webhook notifications, we ensure that any changes made in Cloudinary are promptly reflected in Craft, maintaining seamless synchronization between the two platforms. This feature improves the workflow efficiency and ensures consistency between user interactions in both environments.

- [x] Handle folder creation
- [x] Handle folder deletion
- [x] Handle asset upload
- [x] Handle asset rename
- [x] Handle asset deletion
- [x] Adapt to base folder setting