### PR TITLE
Fix uploads in dynamic folder mode

### DIFF
--- a/src/controllers/NotificationsController.php
+++ b/src/controllers/NotificationsController.php
@@ -61,6 +61,7 @@ class NotificationsController extends Controller
         // Process notification
         $notificationType = $this->request->getRequiredBodyParam('notification_type');
         $baseFolder = App::parseEnv($fs->baseFolder);
+        $hasDynamicFolders = $fs->hasDynamicFolders;
 
         switch ($notificationType) {
             case 'create_folder':
@@ -68,11 +69,11 @@ class NotificationsController extends Controller
             case 'delete_folder':
                 return $this->_processDeleteFolder($volumeId, $baseFolder);
             case 'upload':
-                return $this->_processUpload($volumeId, $baseFolder, $fs);
+                return $this->_processUpload($volumeId, $baseFolder, $hasDynamicFolders);
             case 'delete':
                 return $this->_processDelete($volumeId, $baseFolder);
             case 'rename':
-                return $this->_processRename($volumeId, $baseFolder);
+                return $this->_processRename($volumeId, $baseFolder, $hasDynamicFolders);
             default:
                 return $this->asSuccess();
         }
@@ -146,10 +147,8 @@ class NotificationsController extends Controller
         return $this->asSuccess();
     }
 
-    private function _processUpload($volumeId, $baseFolder, $fs): Response
+    private function _processUpload($volumeId, $baseFolder, $hasDynamicFolders = false): Response
     {
-        $hasDynamicFolders = $fs->dynamicFolders;
-
         $publicId = $this->request->getRequiredBodyParam('public_id');
         $size = $this->request->getRequiredBodyParam('bytes');
 
@@ -269,12 +268,17 @@ class NotificationsController extends Controller
         return $this->asSuccess();
     }
 
-    private function _processRename($volumeId, $baseFolder): Response
+    private function _processRename($volumeId, $baseFolder, $hasDynamicFolders = false): Response
     {
         $resourceType = $this->request->getRequiredBodyParam('resource_type');
         $fromPublicId = $this->request->getRequiredBodyParam('from_public_id');
         $toPublicId = $this->request->getRequiredBodyParam('to_public_id');
-        $folder = $this->request->getRequiredBodyParam('folder');
+
+        if($hasDynamicFolders) {
+            $folder = $this->request->getRequiredBodyParam('asset_folder');
+        } else {
+            $folder = $this->request->getRequiredBodyParam('folder');
+        }
 
         $fromFilename = basename($fromPublicId);
         $fromFolder = dirname($fromPublicId);

--- a/src/controllers/NotificationsController.php
+++ b/src/controllers/NotificationsController.php
@@ -221,14 +221,14 @@ class NotificationsController extends Controller
         return $this->asSuccess();
     }
 
-    private function _processDelete($volumeId, $baseFolder): Response
+    private function _processDelete($volumeId, $baseFolder, bool $hasDynamicFolders): Response
     {
         $resources = $this->request->getRequiredBodyParam('resources');
 
         foreach ($resources as $resource) {
             $resourceType = $resource['resource_type'];
             $publicId = $resource['public_id'];
-            $folder = $resource['folder'];
+            $folder = $hasDynamicFolders ? $resource['asset_folder'] : $resource['folder'];
 
             if (!empty($baseFolder)) {
                 if ($folder !== $baseFolder && !str_starts_with($folder, $baseFolder . '/')) {

--- a/src/controllers/NotificationsController.php
+++ b/src/controllers/NotificationsController.php
@@ -147,16 +147,14 @@ class NotificationsController extends Controller
         return $this->asSuccess();
     }
 
-    private function _processUpload($volumeId, $baseFolder, $hasDynamicFolders = false): Response
+    private function _processUpload($volumeId, $baseFolder, bool $hasDynamicFolders = false): Response
     {
         $publicId = $this->request->getRequiredBodyParam('public_id');
         $size = $this->request->getRequiredBodyParam('bytes');
-
-        if($hasDynamicFolders) {
-            $folder = $this->request->getRequiredBodyParam('asset_folder');
-        } else {
-            $folder = $this->request->getRequiredBodyParam('folder');
-        }
+        $folder = match ($hasDynamicFolders) {
+            true => $this->request->getRequiredBodyParam('asset_folder'),
+            false => $this->request->getRequiredBodyParam('folder'),
+        };
 
         if (!empty($baseFolder)) {
             if ($folder !== $baseFolder && !str_starts_with($folder, $baseFolder . '/')) {
@@ -268,17 +266,15 @@ class NotificationsController extends Controller
         return $this->asSuccess();
     }
 
-    private function _processRename($volumeId, $baseFolder, $hasDynamicFolders = false): Response
+    private function _processRename($volumeId, $baseFolder, bool $hasDynamicFolders = false): Response
     {
         $resourceType = $this->request->getRequiredBodyParam('resource_type');
         $fromPublicId = $this->request->getRequiredBodyParam('from_public_id');
         $toPublicId = $this->request->getRequiredBodyParam('to_public_id');
-
-        if($hasDynamicFolders) {
-            $folder = $this->request->getRequiredBodyParam('asset_folder');
-        } else {
-            $folder = $this->request->getRequiredBodyParam('folder');
-        }
+        $folder = match ($hasDynamicFolders) {
+            true => $this->request->getRequiredBodyParam('asset_folder'),
+            false => $this->request->getRequiredBodyParam('folder'),
+        };
 
         $fromFilename = basename($fromPublicId);
         $fromFolder = dirname($fromPublicId);


### PR DESCRIPTION
Another issue i ran into seems to be related to dynamic folder mode. In my case, this is enabled, and it seems to be the new default and only option for new Cloudinary accounts. I noticed, however, that you apparently dropped support for it in the second Version of this plugin? As soon as I'll be upgrading to Craft 5 this would likely become an issue, so i'd love to hear your thoughts on this. Since i now rely on this plugin i'd obviously be happy to help :)

As for now, i noticed that at least the upload and the rename webhooks do not work with dynamic folder mode, presumably because the parameter for the folder is called `asset_folder` instead of `folder`?

I have no way now to verify this with an account that is in 'fixed' folder mode, but this seems to do the trick for me.

Thanks!